### PR TITLE
chore(ruff): remove unused Dict import in CacheClient

### DIFF
--- a/dotmac_infra/platform/cache_client.py
+++ b/dotmac_infra/platform/cache_client.py
@@ -3,7 +3,7 @@ Platform SDK Cache Client (Python)
 Provides caching operations with tenant isolation and observability
 """
 
-from typing import Dict, Optional, Any
+from typing import Optional, Any
 from datetime import datetime, timedelta
 import json
 


### PR DESCRIPTION
This PR removes an unused `Dict` import from `dotmac_infra/platform/cache_client.py` to satisfy Ruff linting. Also ensures typing and decorators remain consistent with the SDK typing hardening work.

- Remove unused import flagged by Ruff (F401)
- No functional changes

Once merged, CI should go green for dotmac-infra.